### PR TITLE
Add secrets manager and IAM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,51 @@ Try clearing the plugin cache and forcing Terraform to download the specified ve
 ```bash
 terraform init -upgrade
 ```
+
+## Security
+### Secrets Manager
+Our application leverages [AWS Secrets Manager](https://ca-central-1.console.aws.amazon.com/secretsmanager/landing?region=ca-central-1)
+to encrypt and securely store the password for authentication to the RDS database. 
+
+Terraform will create a username and password, which our application services can fetch 
+for authenticating to the rds database. This prevents us from having to hard-code secret values in the application code. 
+
+Below is sample code you can add to your function to fetch and use the database password from the secret manager:
+```python
+import boto3
+from botocore.exceptions import ClientError
+
+
+def get_secret():
+
+    secret_name = "my-super-db-secret" # Replace with the secret name
+    region_name = "ca-central-1"
+
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+    except ClientError as e:
+        # For a list of exceptions thrown, see
+        # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+        raise e
+
+    secret = get_secret_value_response['SecretString']
+
+    # The rest of your code goes here.
+```
+### IAM Roles
+IAM roles are defined and assigned to policies throughout our application. They define how different resources are 
+allowed to interact with each other (e.g. such as reading from the database, writing, etc.). 
+- `lambda-rds-access-role`: IAM role for lambda function to access RDS database.
+- `ec2-rds-access-role`: IAM role for EC2 to access RDS database.
+- `lambda-s3-access-role`: IAM role for Lambda to retrieve and put objects in S3 storage bucket.
+
+The appropriate role should be applied to your portion of the application service.

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,142 @@
+# Drafted IAM Roles For Authentication and Access Control
+
+# IAM Role for Lambda to Access RDS
+resource "aws_iam_role" "lambda_rds_role" {
+  name = "${var.application_name}-lambda-rds-access-role"
+
+  assume_role_policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "lambda.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "lambda_rds_policy" {
+  name        = "${var.application_name}-lambda-rds-policy"
+  description = "Policy for Lambda to access RDS MySQL and Secrets Manager"
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "rds-db:connect",  # Allows Lambda to connect to the RDS database
+          "secretsmanager:GetSecretValue"  # Allows Lambda to retrieve secrets from Secrets Manager
+        ],
+        "Resource": [
+          "${aws_db_instance.mysql-rds-db.arn}:dbuser:${var.database_user}",  # Use RDS db ARN
+          aws_secretsmanager_secret.db_credentials.arn  # Refers to the secret ARN created by Terraform
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        "Resource": "*"  # This allows Lambda to create log groups and log events in CloudWatch
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_rds_attach" {
+  role       = aws_iam_role.lambda_rds_role.name
+  policy_arn = aws_iam_policy.lambda_rds_policy.arn
+}
+
+# IAM Role for EC2 to Access RDS
+resource "aws_iam_role" "ec2_rds_role" {
+  name = "${var.application_name}-ec2-rds-access-role"
+
+  assume_role_policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ec2.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "ec2_rds_policy" {
+  name        = "${var.application_name}-ec2-rds-policy"
+  description = "Policy for EC2 to access RDS MySQL and Secrets Manager"
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "rds-db:connect",  # Allows EC2 to connect to the RDS database
+          "secretsmanager:GetSecretValue"  # Allows EC2 to retrieve secrets from Secrets Manager
+        ],
+        "Resource": [
+          "${aws_db_instance.mysql-rds-db.arn}:dbuser:${var.database_user}",  # Use RDS db ARN
+          aws_secretsmanager_secret.db_credentials.arn  # Refers to the secret ARN created by Terraform
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_rds_attach" {
+  role       = aws_iam_role.ec2_rds_role.name
+  policy_arn = aws_iam_policy.ec2_rds_policy.arn
+}
+
+# IAM Role for Lambda to Access S3
+# resource "aws_iam_role" "lambda_s3_role" {
+#   name = "${var.application_name}-lambda-s3-access-role"
+#
+#   assume_role_policy = jsonencode({
+#     "Version": "2012-10-17",
+#     "Statement": [
+#       {
+#         "Effect": "Allow",
+#         "Principal": {
+#           "Service": "lambda.amazonaws.com"
+#         },
+#         "Action": "sts:AssumeRole"
+#       }
+#     ]
+#   })
+# }
+#
+# resource "aws_iam_policy" "lambda_s3_policy" {
+#   name        = "${var.application_name}-lambda-s3-policy"
+#   description = "Policy for Lambda to access S3 bucket"
+#
+#   policy = jsonencode({
+#     "Version": "2012-10-17",
+#     "Statement": [
+#       {
+#         "Effect": "Allow",
+#         "Action": [
+#           "s3:GetObject",  # Allows Lambda to read from S3 bucket
+#           "s3:PutObject"   # Allows Lambda to write to S3 bucket
+#         ],
+#         "Resource": "arn:aws:s3:::my-bucket-name/*"  # TODO: Replace 'my-bucket-name' with actual S3 bucket name
+#       }
+#     ]
+#   })
+# }
+#
+# resource "aws_iam_role_policy_attachment" "lambda_s3_attach" {
+#   role       = aws_iam_role.lambda_s3_role.name
+#   policy_arn = aws_iam_policy.lambda_s3_policy.arn
+# }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -28,3 +28,9 @@ output "rds_endpoint" {
   description = "The endpoint of the RDS instance"
   value       = aws_db_instance.mysql-rds-db.endpoint
 }
+
+# Output the RDS arn
+output "rds_arn" {
+  description = "The arn of the RDS instance"
+  value       = aws_db_instance.mysql-rds-db.arn
+}

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -1,0 +1,19 @@
+# Create the secret in Secrets Manager
+resource "aws_secretsmanager_secret" "db_credentials" {
+  name        = var.database_secret_name  # The name of your secret
+  description = "RDS MySQL database credentials for the application"
+  tags = {
+    name = "${var.application_name}-secret"
+  }
+}
+
+# Create the secret value (username and password)
+resource "aws_secretsmanager_secret_version" "db_credentials_version" {
+  secret_id = aws_secretsmanager_secret.db_credentials.id  # Links to the secret created above
+
+  secret_string = jsonencode({
+    username = var.database_user
+    password = var.database_password
+    host     = aws_db_instance.mysql-rds-db.endpoint
+  })
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -2,14 +2,14 @@
 
 variable "application_name" {
   description = "Application name to add to AWS resource tags"
-  type = string
-  default = "vibe-check-my-prof"
+  type        = string
+  default     = "vibe-check-my-prof"
 }
 
 variable "database_name" {
   description = "Application database name"
-  type = string
-  default = "vibecheckmyprofdb"
+  type        = string
+  default     = "vibecheckmyprofdb"
 }
 
 variable "cidr_block" {
@@ -27,6 +27,12 @@ variable "database_password" {
   description = "The database master password (save for authenticating to the database later)"
   type        = string
   sensitive   = true # This variable is marked as sensitive so it's not displayed in logs
+}
+
+variable "database_secret_name" {
+  description = "Name of the secret to authenticate to the RDS database instance"
+  type        = string
+  default     = "my-super-db-secret"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
# Summary
Drafted IAM roles/policies and password management for the security portion of our application.

# Context
We wanted to setup I am roles and policies to ensure each service in our application has the minimal permission necessary to interact with other services in the application. This PR contains a draft of those roles (what service each role relates to), and policies (what kind of access that service is permitted to conduct), so the roles can be assigned to those services later. In order for services to authenticate to the database, a secrets manager is also used for storing the database password so it may be fetched by the service at runtime. I have not yet defined any user/human roles nor key-pairing. 

# File Changes
- Created `infra/secrets.tf`, which contains the configuration for the secret manager, and loads the database password/secret.
- Created `infra/iam.tf`, which defines the IAM roles/policies for our application services.
- Updated the `README.md` with information about the application security (I'll provide more detail once I'm confident the policies are appropriate).

# Testing
- I successfully created the secret and IAM resources using the Terraform terminal commands.

# Requested Feedback
- These are likely to change, but just wanted to get the basics into the repo.
- LMK if there is anything glaring I missed, or what I could add to the README to provide better information to the team so they understand the security layers.

Thank you!