### PR TITLE
Add issue templates and update CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Log a bug or unexpected behavior
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Bug Report
+
+### Description
+A clear and concise description of what the bug or problem is.
+
+### Steps to Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+### Expected Behavior
+Describe what you expected to happen, or what should happen when the bug is fixed.
+
+### Additional Context
+Share any additional details or context, screenshots if helpful, etc. 

--- a/.github/ISSUE_TEMPLATE/general_issue.md
+++ b/.github/ISSUE_TEMPLATE/general_issue.md
@@ -1,0 +1,21 @@
+---
+name: General Issue
+about: Log a task, issue or feature request
+assignees: ''
+---
+
+## Issue or Task
+
+### Problem or Gap
+Describe the thing that is missing or needs to be done.
+
+### Proposed Solution
+Share details of how you propose the work should be done.
+
+### Prerequisites
+Does anything need to be done first? Any information or tasks you're waiting on from other teams?
+
+### Steps to Complete
+A high level checklist breaking down the work into distinct steps or tasks, if any.
+- [ ] A checklist item
+- [ ] Another item 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,9 @@ You will see an output with error messages and locations for all linter errors. 
 
 # Repository Structure
 
+## /request_lambda folder
+Holds files for creating the containerized Lambda function that runs backend computation for the app. This includes RMP API use, sentiment analysis, frontend formatting and database interaction.
+
 ## /web folder
 Holds files relating to hosting the app webpage. There is a missing `config.js` folder that you will need to create following the setup guide in README.
 


### PR DESCRIPTION
# Summary
We added PR templates, now we have issue templates!

# Context
This will help us be more consistent when writing issues

# File Changes
new files in `.github/ISSUE_TEMPLATES` with what it says on the tin
edit to CONTRIBUTING.md with a note about `request_lambda`

# Testing
Tested the markdown view of the new files and added them in the right folder to be templates

# Requested Feedback
Feedback on the template contents would be great!