### PR TITLE
Gradient colors added to stat box background-color

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -130,7 +130,7 @@ function renderResponse(data) {
                     <div class="subjectivity-text stats-text">subjectivity</div>
                 </div>
                 <div class="flex-col spelling stats-box"
-                     style="background-color: ${toGradient(spellingquality, 0.9, 1)}">
+                     style="background-color: ${toGradient(spellingquality, 90, 100)}">
                     <div class="spelling-stat stats-stat">${spellingquality}%</div>
                     <div class="spelling-text stats-text">spelling</div>
                 </div>
@@ -202,7 +202,7 @@ function renderCourse(courseData) {
                         <div class="subjectivity-text stats-text">subjectivity</div>
                     </div>
                     <div class="flex-col spelling stats-box"
-                         style="background-color: ${toGradient(spellingquality, 0.9, 1)}">
+                         style="background-color: ${toGradient(spellingquality, 90, 100)}">
                         <div class="spelling-stat stats-stat">${spellingquality}%</div>
                         <div class="spelling-text stats-text">spelling</div>
                     </div>


### PR DESCRIPTION
# Summary
This PR applies value-dependent color gradients to each stat box.

# Context
We wanted colorful displays that would reflect the data and add visual interest. 

# File Changes
`app.js` New function for calculating gradient color and new logic using it.
The first 4 types of stat-box range from 0-5. I set spelling to range from 90-100. It might occasionally go lower, but I think this will give a good gradient.

# Testing
Tested both locally and on S3, appearance looks correct for range of each value:
![image](https://github.com/user-attachments/assets/0f4ff5a1-7f1a-4b83-8a8a-38ebb6e33ac6)

# Requested Feedback
Feedback on colors? Double check math/logic in the changes, I caught a couple of my own errors already.
WARNING: if you test it on S3 make sure your lambda is from main branch or accurate_dummy_response branch, not from recent SA changes

### Checklist
- [x] I have re-uploaded to S3 bucket and tested the VibeCheck button response (if these changes affect `/web` files)
