### PR TITLE
Add loading spinner with logic to hide and show

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -23,6 +23,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Function to send API request to the API Gateway endpoint
     function sendApiRequest(professorUrl) {
+        const loadingOverlay = document.getElementById('loading');
+        loadingOverlay.style.display = 'flex';
+
         // The API URL is loaded from config.js
         // eslint-disable-next-line no-undef
         fetch(config.apiUrl, {
@@ -35,12 +38,14 @@ document.addEventListener('DOMContentLoaded', function() {
         })
             .then(response => response.json())
             .then(data => {
+                loadingOverlay.style.display = 'none';
                 // Display the API response in the text area
                 responseField.value = `Response: ${JSON.stringify(data, null, 2)}`;
                 const responseData = JSON.parse(data.body);
                 renderResponse(responseData);
             })
             .catch(error => {
+                loadingOverlay.style.display = 'none';
                 // Display error message if the request fails
                 responseField.value = `Error: ${error.message}`;
             });

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,9 @@
         </div>
         <p id="error" class="error-message"></p>
         <textarea id="responseField" class="response-field" readonly></textarea>
+        <div id="loading" class="loading-overlay">
+            <div class="loading-spinner-large"></div>
+        </div>
         <div id="response">
             <div id="response-prof" class="response-prof">
             </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -213,3 +213,31 @@ body {
 .stats-text {
     font-weight: bold;
 }
+
+.loading-overlay {
+    display: none; /* Hidden by default */
+    width: 100%;
+    max-width: 800px;
+    height: 300px;
+    background: rgba(255, 255, 255, 0.3);
+    justify-content: center;
+    align-items: center;
+    margin-top: 1rem;
+    border-radius: 1rem;
+    z-index: 1000;
+}
+
+/* Loading spinner animation */
+.loading-spinner-large {
+    border: 20px solid rgba(224, 224, 224, 0); /* Light grey with 50% opacity */
+    border-top: 20px solid rgba(61, 134, 255, 0.8); /* Main color with 50% opacity */
+    border-radius: 50%;
+    width: 120px;
+    height: 120px;
+    animation: spin 1.5s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
# Summary
This PR adds a loading spinner that shows while waiting for an API response.

# Context
Our API requests might take a long time so we want a loading animation to show during waiting periods.

# File Changes
`index.html` add spinner divs
`styles.css` styling and animation for the spinner
`app.js` logic to show and hide the spinner during wait times

# Testing
Tested locally and on S3, spinner appears and disappears as expected. When manually "show" the spinner for longer periods it looks good.
<img src="https://github.com/user-attachments/assets/edc24a73-0cb7-4b42-8520-6dd2b323e50c" alt="VCMP - loading animation" width="400">

# Requested Feedback
Please review the js logic and css styles. Feedback on placement/size is welcome. Feedback on design less welcome (not so easy to change, but it depends on what changed to).

### Checklist
- [x] I have re-uploaded to S3 bucket and tested the VibeCheck button response (if these changes affect `/web` files)
