### PR TITLE
Add 15s polling to front end

### DIFF
--- a/request_lambda/lambda1/app.py
+++ b/request_lambda/lambda1/app.py
@@ -53,39 +53,28 @@ def lambda_handler(event, context):
             'statusCode': 200,
             'body': json.dumps(response)
         }
-
-    # Get the professor name from RMP API for responses
-    try:
-        professor_name = rmp_api.get_prof_name(professor_id)
-    except ValueError:
-        return {
-            'statusCode': 400,
-            'body': json.dumps({"error": f"ID {professor_id} not found."})
-        }
-
     # Case: request exists, but data is still being processed
-    if prof_status == "in-progress":
+    elif prof_status == "in-progress":
         # Send a response to inform analysis is underway
         print("Analysis in progress for professor.")
         response = {
-            "STATUS": "ANALYSIS_IN_PROGRESS",
-            "PROF_NAME": professor_name,
+            "STATUS": "ANALYSIS_IN_PROGRESS"
         }
     # Case: request does not exist, or data is stale
     elif prof_status == "not-started":
         if count > 0:  # Request has timed out
             response = {
-                "STATUS": "ANALYSIS_FAILED",
-                "PROF_NAME": professor_name
+                "STATUS": "ANALYSIS_FAILED"
             }
         else:
             # Start analysis and send a response to inform analysis has begun
             try:
                 professor_name = rmp_api.get_prof_name(professor_id)
             except ValueError:
+                print(f"ID {professor_id} not found.")
                 return {
                     'statusCode': 400,
-                    'body': json.dumps({"error": f"ID {professor_id} \
+                    'body': json.dumps({"error": f"ID {professor_id} was\
                                         not found."})
                 }
             client.invoke(
@@ -99,7 +88,7 @@ def lambda_handler(event, context):
                 "STATUS": "ANALYSIS_REQUESTED",
                 "PROF_NAME": professor_name
             }
-    # Case: colleen's code fucked up or something
+    # Case: database gave error message
     else:
         print("Status = 'error'")
         response = {"error": "Unknown error with prof status"}

--- a/web/app.js
+++ b/web/app.js
@@ -72,6 +72,7 @@ document.addEventListener('DOMContentLoaded', function() {
         clearInterval(pollingInterval);
 
         let count = 0; // Initialize poll count
+        let prof_name = null;
 
         const checkStatus = async () => {
             // Send the request with the current count
@@ -85,9 +86,14 @@ document.addEventListener('DOMContentLoaded', function() {
                     renderResponse(data.DATA);
                     responseField.value = `Response: ${JSON.stringify(data, null, 2)}`;
                 } else if (data.STATUS === 'ANALYSIS_REQUESTED') {
+                    prof_name = data.PROF_NAME;
                     messageElement.textContent = 'New data! Processing takes a while.';
                 } else if (data.STATUS === 'ANALYSIS_IN_PROGRESS') {
-                    messageElement.textContent = 'Data processing is in progress.';
+                    if (prof_name) {
+                        messageElement.textContent = `Data processing for ${prof_name} is in progress.`;
+                    } else {
+                        messageElement.textContent = 'Data processing is in progress.';
+                    }
                 } else if (data.STATUS === 'ANALYSIS_FAILED') {
                     messageElement.textContent = 'Analysis failed for unknown reasons.';
                     clearRequestInProgress(); // Stop polling if analysis failed


### PR DESCRIPTION
# Summary
This PR introduces polling, allowing the front end to poll every 15s for changes and retrieve data as soon as it's ready

# Context
This will allow users to wait with the loading screen without having to re-request to get data.

# File Changes
`app.js` introduce polling mechanism
`/lambda1/app.py` optimize responses for polling, eliminate extra RMP API calls

# Testing
Tested end-to-end and all works as expected.

# Requested Feedback
End-to-end testing please

### Checklist
- [X] I have rebuilt and tested the lambda container (if these changes affect `/request_lambda` files)
- [X] I have re-uploaded to S3 bucket and tested the VibeCheck button response (if these changes affect `/web` files)
