### PR TITLE
Size vibes/feels proportionally

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -298,7 +298,7 @@ function renderEmojis(reviewsData) {
 function getProportionalFontSize(proportion) {
     // Get font size for the proportion threshold passed, in rem
     for(let [threshold, fontSize] of PROPORTIONAL_FONT_SIZES) {
-        if(proportion > threshold) {
+        if(proportion >= threshold) {
             return fontSize; 
         }
     }


### PR DESCRIPTION
# Summary
Makes the vibes/feels text and emojis sized based on what proportion of the reviews they represent.

# Context
Allows users to visually see what proportion of the reviews different sentiments have, at a glance based on size. 

# File Changes
- web/app.js - Adds styling to feels/vibe elements to adjust font-size based on the calculated proportion of reviews that feel/vibe relates to

# Testing
- On the one-lambda dummy setup, the proportions are calculated as expected and the appropriate font-sizes are applied as expected for both feels and vibes

# Requested Feedback
Let me know if there's any changes we might want to...
- cleaning up the code
- how we handle mapping the feel/vibe proportions to their font-size, etc.

or anything else:)

### Checklist
- [ ] I have rebuilt and tested the lambda container (if these changes affect `/request_lambda` files)
- [x] I have re-uploaded to S3 bucket and tested the VibeCheck button response (if these changes affect `/web` files)
