### PR TITLE
fixed CSS border width

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -168,7 +168,7 @@ body {
 .response-course-options {
     background-color: #f9c5d1;
     color: black;
-    font-weight: 550;
+    font-weight: 500;
     border-width: 0;
     border-radius: 0.4rem;
 }


### PR DESCRIPTION
# Summary
We found a small bug with the course selection dropdown showing before entering a link and being positioned in the middle instead of the left on a Mac when testing on S3. 

# Context
Small CSS style error on a line: Changed border-width: 0cap; to border-width: 0;

# File Changes
web/style.css

# Testing
Works now on my Mac laptop when testing on S3. The dropdown no longer shows before entering a link and it is now positioned to the left.
